### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,22 +5,22 @@ django-testing-base
     :target: http://django-testing-base.readthedocs.org/en/latest/
     :alt: Documentation
     
-.. image:: https://pypip.in/version/django-testing-base/badge.svg?text=version&style=flat
+.. image:: https://img.shields.io/pypi/v/django-testing-base.svg?label=version&style=flat
     :target: https://pypi.python.org/pypi/django-testing-base/
     :alt: Latest Version
 
-.. image:: https://pypip.in/status/django-testing-base/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/status/django-testing-base.svg?style=flat
     :target: https://pypi.python.org/pypi/django-testing-base/
     :alt: Development Status
 
-.. image:: https://pypip.in/py_versions/django-testing-base/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/django-testing-base.svg?style=flat
     :target: https://pypi.python.org/pypi/django-testing-base/
     :alt: Supported Python versions
 
 .. image:: http://img.shields.io/badge/django-1.6%2C%201.7-green.svg?style=flat
     :alt: Django Version
 
-.. image:: https://pypip.in/license/django-testing-base/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/django-testing-base.svg?style=flat
     :target: https://pypi.python.org/pypi/django-testing-base/
     :alt: License
 
@@ -28,7 +28,7 @@ django-testing-base
      :target: https://requires.io/github/tctimmeh/django-testing-base/requirements/?branch=master
      :alt: Requirements Status
 
-.. image:: https://pypip.in/download/django-testing-base/badge.svg?period=month&style=flat
+.. image:: https://img.shields.io/pypi/dm/django-testing-base.svg?style=flat
     :target: https://pypi.python.org/pypi//django-testing-base/
     :alt: Downloads
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-testing-base))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-testing-base`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.